### PR TITLE
Change Display Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.532</version>
+        <version>2.37</version>
     </parent>
 
     <artifactId>read-only-configurations</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>read-only-configurations</artifactId>
-    <version>1.11-SNAPSHOT</version>
+    <version>1.12-SNAPSHOT</version>
     <name>Read-only configurations</name>
     <packaging>hpi</packaging>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Read-only+configurations+plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>read-only-configurations</artifactId>
-    <version>1.12-SNAPSHOT</version>
+    <version>1.11-SNAPSHOT</version>
     <name>Read-only configurations</name>
     <packaging>hpi</packaging>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Read-only+configurations+plugin</url>

--- a/src/main/java/org/jenkinsci/plugins/readonly/JenkinsConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/readonly/JenkinsConfiguration.java
@@ -78,7 +78,7 @@ public class JenkinsConfiguration implements RootAction {
     }
 
     public String getDisplayName() {
-        return "Global configuration";
+        return "Global Configuration (Read-Only)";
     }
 
     public String getUrlName() {


### PR DESCRIPTION
Changing display name from `Global configuration` to `Global Configuration (Read-Only)` to clarify that the link is to read only configuration and not global configuration which is updatable.